### PR TITLE
handle lone double quotes and numbers preceding double quotes

### DIFF
--- a/lib/replacements.js
+++ b/lib/replacements.js
@@ -23,8 +23,10 @@ module.exports = [
   [new RegExp(`((\\u2018[^']*)|[${pL}])'([^0-9]|$)`, 'ig'), '$1\u2019$3'],
   // backwards apostrophe
   [new RegExp(`(\\B|^)\\u2018(?=([^\\u2018\\u2019]*\\u2019\\b)*([^\\u2018\\u2019]*\\B${nonWord}[\\u2018\\u2019]\\b|[^\\u2018\\u2019]*$))`, 'ig'), '$1\u2019'],
-  // double prime
-  [/"/g, '\u2033'],
+  // double straigt quotes -> opening curly quote
+  [/"/g, '\u201C'],
+  // opening curly quote preceding number -> double prime quote
+  [/([1-9])(“)/g, '$1\u2033'],
   // prime
   [/'/g, '\u2032']
 ];


### PR DESCRIPTION
-  Replaces all remaining double quotes with opening curly quotes instead of double prime quotes.
-  Afterwards, if there are any double prime quotes following numbers, convert them to double prime quotes.